### PR TITLE
remove plus symbol from css replacer

### DIFF
--- a/change/rollup-plugin-fast-tagged-templates-53c47e5d-77a2-4a57-b73b-475e06350aff.json
+++ b/change/rollup-plugin-fast-tagged-templates-53c47e5d-77a2-4a57-b73b-475e06350aff.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "remove plus symbol from css replacer",
+  "packageName": "rollup-plugin-fast-tagged-templates",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/index.mjs
+++ b/index.mjs
@@ -35,8 +35,8 @@ export default function FASTTaggedTemplates(
             match.includes(replacer) ? match : ""
         );
 
-        // Remove spaces before and after the following characters: + ~ > : , / { }
-        source = source.replace(/\s*([+~>:,;/{}])\s+/g, "$1");
+        // Remove spaces before and after the following characters: ~ > : , / { }
+        source = source.replace(/\s*([~>:,;/{}])\s+/g, "$1");
 
         // Remove the last semicolon in each block
         source = source.replace(/;}/g, "}");


### PR DESCRIPTION
This was causing issues with `calc()` values, which require spaces around the `+` operator.