### PR TITLE
Fix: skip call expressions with non-transformer function names

### DIFF
--- a/change/rollup-plugin-fast-tagged-templates-797de0a0-17cc-4582-9e3c-3917a18847f0.json
+++ b/change/rollup-plugin-fast-tagged-templates-797de0a0-17cc-4582-9e3c-3917a18847f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "avoid transforming call expressions with non-transformer function names",
+  "packageName": "rollup-plugin-fast-tagged-templates",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/index.mjs
+++ b/index.mjs
@@ -98,7 +98,7 @@ export default function FASTTaggedTemplates(
                     /** @type {import("rollup").RollupAstNode<import("estree").TemplateElement>[]} */
                     const quasis = node.quasi?.quasis ?? node.arguments?.[0]?.quasis;
 
-                    if (!name || !quasis) {
+                    if (!name || !quasis || !transformers[name]) {
                         return;
                     }
 

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -226,4 +226,44 @@ describe("FASTTaggedTemplates", () => {
 
         assert.match(code, /html.partial\(\`<div><slot><\/slot><\/div>\`\);/);
     });
+
+    test("should not transform call expressions with non-transformer function names", async t => {
+        const plugins = FASTTaggedTemplates();
+        const input = "component.js";
+
+        const dir = realFs(getTestName(t), {
+            [input]: dedent`
+                throw TypeError(\`Expected a string but got \${typeof value}\`);
+            `,
+        });
+
+        const output = await build({ dir, input, plugins });
+
+        const [{ code }] = output;
+
+        assert.match(code, /TypeError\(`Expected a string but got \$\{typeof value\}`\)/);
+    });
+
+    test("should not transform call expressions with non-transformer names alongside real transforms", async t => {
+        const plugins = FASTTaggedTemplates();
+        const input = "component.js";
+
+        const dir = realFs(getTestName(t), {
+            [input]: dedent`
+                const message = TypeError(\`invalid value: \${val}\`);
+                export const styles = css\`
+                    :host {
+                        color: red;
+                    }
+                \`;\n
+            `,
+        });
+
+        const output = await build({ dir, input, plugins });
+
+        const [{ code }] = output;
+
+        assert.match(code, /TypeError\(`invalid value: \$\{val\}`\)/);
+        assert.match(code, /css\`:host\{color:red\}\`;/);
+    });
 });


### PR DESCRIPTION
Call expressions like `TypeError(`some template literal`)` were being processed by the plugin because the guard only checked for a truthy `name` and `quasis`, but not whether the function name matched a registered transformer. This caused errors when the plugin attempted to minify content from unrelated template literals.

### Changes

- Added a `!transformers[name]` check to the early return guard so only `html` and `css` (or user-provided) tagged templates and call expressions are transformed.
- Added two tests covering the fix:
  - A standalone non-transformer call expression (`TypeError`) is left unchanged.
  - A non-transformer call expression alongside a real `css` tagged template — only the `css` content is transformed.

### Test plan

All 11 tests pass, including the two new ones.